### PR TITLE
Fix contact card display when name missing

### DIFF
--- a/DesignBuddyDesktop/app.js
+++ b/DesignBuddyDesktop/app.js
@@ -485,8 +485,9 @@ document.addEventListener("DOMContentLoaded", () => {
                     const div = document.createElement('div');
                     div.className = 'contact-card';
 
+                    const title = [c.name, c.company].filter(Boolean).join(' - ');
                     const info = `
-                        <h4>${c.name}${c.company ? ' - ' + c.company : ''}</h4>
+                        <h4>${title}</h4>
                         ${c.description ? `<p>${c.description}</p>` : ''}
                         ${c.email ? `<p>Email: <a href="mailto:${c.email}">${c.email}</a></p>` : ''}
                         ${c.phone ? `<p>Phone: ${c.phone}</p>` : ''}


### PR DESCRIPTION
## Summary
- fix contact card title logic in DesignBuddyDesktop so company names show alone when no personal name is provided

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68825f67ae2c8320937fb873221864cd