### PR TITLE
Add STL viewer tab to DesignBuddyDesktop

### DIFF
--- a/DesignBuddyDesktop/index.html
+++ b/DesignBuddyDesktop/index.html
@@ -27,6 +27,11 @@
     </main>
   </div>
 
+    <!-- Three.js libraries for STL Viewer -->
+    <script src="https://cdn.jsdelivr.net/npm/three@0.132.2/build/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.132.2/examples/js/controls/OrbitControls.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.132.2/examples/js/loaders/STLLoader.js"></script>
+
     <script src="fingerSizes.js"></script>
     <script src="contacts.js"></script>
     <script src="app.js"></script>

--- a/DesignBuddyDesktop/partials/news-feed.html
+++ b/DesignBuddyDesktop/partials/news-feed.html
@@ -1,0 +1,3 @@
+<div id="news-feed">
+  <div id="news-list">Loading...</div>
+</div>

--- a/DesignBuddyDesktop/partials/stl-viewer.html
+++ b/DesignBuddyDesktop/partials/stl-viewer.html
@@ -1,0 +1,6 @@
+<div id="stl-viewer">
+  <input type="file" id="stl-file-input" accept=".stl" />
+  <div id="stl-canvas-container">
+    <canvas id="stl-canvas"></canvas>
+  </div>
+</div>

--- a/DesignBuddyDesktop/style.css
+++ b/DesignBuddyDesktop/style.css
@@ -347,3 +347,40 @@ select, input {
     font-size: 0.9rem;
   }
 }
+
+/* STL Viewer */
+#stl-canvas-container {
+  width: 100%;
+  height: 400px;
+  border: 1px solid #ccc;
+  margin-top: 1rem;
+}
+
+#stl-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+/* News Feed */
+.news-feed-section {
+  margin-bottom: 1rem;
+}
+
+.news-feed-section ul {
+  list-style: none;
+  padding-left: 1rem;
+}
+
+.news-feed-section li {
+  margin-bottom: 0.5rem;
+}
+
+.news-feed-section a {
+  color: #007bff;
+  text-decoration: none;
+}
+
+.news-feed-section a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- add a new `stl-viewer.html` partial with a canvas and file input
- load Three.js libraries in `index.html`
- add a `3D Model Viewer` tab in `app.js`
- implement `setupStlViewer` to load and display STL files
- add styles for the viewer canvas
- add `Industry News` tab showing RSS headlines from JCK Online, National Jeweler, and Instore Magazine

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6888353d6f8883209856a2b3563f7ab0