### PR TITLE
Add CAD Preview tab using RhinoPreview

### DIFF
--- a/CAD_Preview/index.html
+++ b/CAD_Preview/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="." />
+    <link rel="icon" type="image/svg+xml" href="../assets/svg/logo.svg" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet" />
+    <title>CAD Preview</title>
+  </head>
+  <body>
+    <link rel="stylesheet" href="style.css" />
+
+    <div class="header" id="myHeader">
+      <h2>CAD Preview</h2>
+      <a onclick="history.back()">Back</a>
+    </div>
+
+    <div id="preview" class="square"></div>
+    <input id="fileInput" type="file" accept=".3dm" />
+
+    <script type="module">
+      import { RhinoPreview } from 'https://cdn.jsdelivr.net/gh/DerLando/RhinoPreview/dist/RhinoPreview.esm.js';
+
+      const container = document.getElementById('preview');
+      const rp = new RhinoPreview(container);
+      document.getElementById('fileInput').addEventListener('change', (e) => {
+        if (e.target.files.length > 0) {
+          rp.load(e.target.files[0]);
+        }
+      });
+    </script>
+  </body>
+</html>
+

--- a/CAD_Preview/style.css
+++ b/CAD_Preview/style.css
@@ -1,0 +1,94 @@
+#app {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-align: center;
+  color: #2c3e50;
+  margin-top: 0px;
+}
+
+:root{
+  --color1: #202020;
+  --color2: #ffffff;
+  --color3: #2c3e50;
+  --colorTest : #ff0080;
+}
+
+body {
+  background : var(--color2);
+  padding : 0px;
+  margin : auto;
+  font-family: 'Roboto', sans-serif;
+}
+
+h2{
+  font-size: 1rem;
+  padding: 10px, 20px;
+}
+  
+a {
+  display: block;
+  max-width: 400px;
+  margin: 10px auto 0px auto;
+  padding: 10px 20px;
+  font-size: 0.95rem;
+  background-color: var(--color1);
+  color: var(--color2);
+  border: 2px solid var(--color2);
+  border-radius: 26px;
+  text-decoration: none;
+  -webkit-transition: all 150ms ease-in-out;
+  transition: all 150ms ease-in-out;
+  text-align: center;
+}
+
+/* Style the header */
+.header {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+
+  text-align: center;
+  padding: 10px 16px;
+  background: #ffffff;
+  
+  color: var(--color3);
+}
+
+#preview {
+  margin: 0 auto 0px auto;
+  background-color: var(--colorTest);
+  position: relative;
+  height: 100vh;
+  max-height: 400px;
+  max-width: 400px;
+
+  display: block;
+}
+
+
+select {
+  padding: 10px 16px;
+  color:#202020;
+  background-color: #ffffff;
+  border: 1px solid #d113a2;
+  cursor: pointer;
+  border-radius: 5px;
+
+  /* replace appearance arrow 
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  
+  background-image: url('data:image/svg+xml;utf8,<svg xmls="http://www.w3.org/2000/svg" width="100" height="50"><polygon points="0,0 100,0 50,50" style="fill:%23666666;" /></svg>');
+  */
+
+}
+
+select:focus,
+select:hover{
+  outline: none;
+  border: 1px solid #ffffff;
+}
+
+select option{
+  background: #ffffff;
+}

--- a/Links/index.html
+++ b/Links/index.html
@@ -70,6 +70,14 @@
         </a>
 
     </div>
+    <div class="section">
+
+        <a class="" href="https://ludovickninja.github.io/CAD_Preview/"
+           onclick="gtag('event', 'link-click', { 'event_category' : 'links', 'event_label' : 'cadPreview' });">
+           CAD Preview
+        </a>
+
+    </div>
 
     <!-- Socials -->
     <h2>Follow Me On</h2>


### PR DESCRIPTION
## Summary
- add `CAD_Preview` page that loads RhinoPreview from CDN and lets the user load `.3dm` files
- update link page with a new tab to access the CAD preview

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68884339c25c8320894645bdf78dc75a