### PR TITLE
Add simple Unreal Engine viewer using three.js

### DIFF
--- a/UnrealViewer/index.html
+++ b/UnrealViewer/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Unreal Engine Viewer</title>
+  <style>
+    body { margin: 0; overflow: hidden; }
+    #viewer { width: 100vw; height: 100vh; }
+  </style>
+</head>
+<body>
+  <div id="viewer"></div>
+  <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/UnrealViewer/main.js
+++ b/UnrealViewer/main.js
@@ -1,0 +1,50 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.153/build/three.module.js';
+import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.153/examples/jsm/controls/OrbitControls.js';
+import { GLTFLoader } from 'https://cdn.jsdelivr.net/npm/three@0.153/examples/jsm/loaders/GLTFLoader.js';
+
+let camera, scene, renderer, controls;
+
+init();
+animate();
+
+function init() {
+  const container = document.getElementById('viewer');
+  scene = new THREE.Scene();
+
+  camera = new THREE.PerspectiveCamera(
+    60,
+    window.innerWidth / window.innerHeight,
+    0.1,
+    1000
+  );
+  camera.position.set(0, 1, 2);
+
+  renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  container.appendChild(renderer.domElement);
+
+  controls = new OrbitControls(camera, renderer.domElement);
+  controls.enableDamping = true;
+
+  const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1);
+  scene.add(light);
+
+  const loader = new GLTFLoader();
+  loader.load('../assets/models/Model.glb', (gltf) => {
+    scene.add(gltf.scene);
+  });
+
+  window.addEventListener('resize', onWindowResize);
+}
+
+function onWindowResize() {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function animate() {
+  requestAnimationFrame(animate);
+  controls.update();
+  renderer.render(scene, camera);
+}


### PR DESCRIPTION
## Summary
- add `UnrealViewer` directory with a minimal WebGL viewer built with three.js
- viewer loads a sample glTF model and provides orbit controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689aaf8015288320bd9c0eae6b2c8f33