### PR TITLE
Add standalone Rush Requests questionnaire (dev build)

### DIFF
--- a/RushRequestsDev/app.js
+++ b/RushRequestsDev/app.js
@@ -1,0 +1,242 @@
+/*
+ * app.js — Rush Requests questionnaire controller (standalone dev build).
+ *
+ * A small render-from-state wizard in plain vanilla JS. The whole body inside
+ * the DOMContentLoaded handler is written so it can be lifted, almost verbatim,
+ * into a setupRushRequests() function inside DesignBuddyDesktop/app.js when this
+ * is migrated into a tab (loadTabContent already calls tab.setup?.() after the
+ * partial is injected, which is the same "run after the DOM exists" contract).
+ *
+ * Depends on window.rushRules (rushRules.js) and window.businessDays
+ * (businessDays.js) — both must load before this file.
+ */
+document.addEventListener("DOMContentLoaded", function () {
+    var rules = window.rushRules;
+    var bd = window.businessDays;
+    var root = document.getElementById("rush-app");
+    if (!root || !rules || !bd) return;
+
+    // All user-facing chrome strings live here so Phase 2 can move them into the
+    // DesignBuddyDesktop i18n `translations` object (en + fr) with t("rush.*").
+    var STRINGS = {
+        progress: function (i, n) { return "Step " + i + " of " + n; },
+        back: "Back",
+        next: "Next",
+        seeAnswer: "See my answer",
+        startOver: "Start over",
+        copy: "Copy summary",
+        copied: "Copied!",
+        required: "Please fill this in before continuing.",
+        chooseOne: "Please choose an option.",
+        resultHeading: "Rush request result",
+        earliest: "Earliest achievable date",
+        capacityNote: function (n) { return "Guideline: up to " + n + " rush requests per day."; },
+        verdict: { approved: "Approved", escalate: "Needs approval", denied: "Not possible" }
+    };
+
+    var state = {
+        steps: rules.questions.slice(), // wizard renders these in order
+        index: 0,
+        answers: {},
+        result: null
+    };
+
+    // ---- helpers -----------------------------------------------------------
+    function currentStep() {
+        return state.steps[state.index];
+    }
+
+    function optionsFor(step) {
+        if (step.options) return step.options;
+        if (step.optionsFrom === "workTypes") {
+            return Object.keys(rules.workTypes).map(function (key) {
+                return { value: key, label: rules.workTypes[key].label };
+            });
+        }
+        return [];
+    }
+
+    function stepError(step) {
+        if (!step.required) return null;
+        var val = state.answers[step.id];
+        if (val === undefined || val === null || String(val).trim() === "") {
+            return step.type === "single" ? STRINGS.chooseOne : STRINGS.required;
+        }
+        return null;
+    }
+
+    function escapeHtml(s) {
+        return String(s)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
+    }
+
+    // ---- rendering ---------------------------------------------------------
+    function render() {
+        if (state.result) {
+            renderResult(state.result);
+            return;
+        }
+        var step = currentStep();
+        var html = "";
+        html += '<div class="rush-progress">' +
+            escapeHtml(STRINGS.progress(state.index + 1, state.steps.length)) + "</div>";
+        html += '<div class="rush-step">' + renderStep(step) + "</div>";
+        html += '<div class="rush-error" id="rush-error" role="alert"></div>';
+        html += renderActions();
+        root.innerHTML = html;
+        wireStep(step);
+    }
+
+    function renderStep(step) {
+        if (step.type === "info") {
+            return '<div class="calculator-description">' + escapeHtml(step.label) + "</div>";
+        }
+        var label = "<label>" + escapeHtml(step.label) + "</label>";
+        if (step.type === "single") {
+            var chips = optionsFor(step).map(function (opt) {
+                var active = state.answers[step.id] === opt.value ? " active" : "";
+                return '<button type="button" class="coverage-button rush-choice' + active +
+                    '" data-value="' + escapeHtml(opt.value) + '">' + escapeHtml(opt.label) + "</button>";
+            }).join("");
+            return label + '<div class="rush-choice-grid">' + chips + "</div>";
+        }
+        if (step.type === "date") {
+            var min = bd.ymd(new Date());
+            var dval = state.answers[step.id] ? ' value="' + escapeHtml(state.answers[step.id]) + '"' : "";
+            return label + '<input type="date" id="rush-field" min="' + min + '"' + dval + " />";
+        }
+        var type = step.type === "number" ? "number" : "text";
+        var ph = step.placeholder ? ' placeholder="' + escapeHtml(step.placeholder) + '"' : "";
+        var val = state.answers[step.id] !== undefined
+            ? ' value="' + escapeHtml(String(state.answers[step.id])) + '"' : "";
+        return label + '<input type="' + type + '" id="rush-field"' + ph + val + " />";
+    }
+
+    function renderActions() {
+        var isLast = state.index === state.steps.length - 1;
+        var backDisabled = state.index === 0 ? " disabled" : "";
+        var nextLabel = isLast ? STRINGS.seeAnswer : STRINGS.next;
+        return '<div class="rush-actions">' +
+            '<button type="button" class="coverage-button" id="rush-back"' + backDisabled + ">" +
+            escapeHtml(STRINGS.back) + "</button>" +
+            '<button type="button" class="coverage-button rush-primary" id="rush-next">' +
+            escapeHtml(nextLabel) + "</button>" +
+            "</div>";
+    }
+
+    function renderResult(result) {
+        var verdictLabel = STRINGS.verdict[result.verdict] || result.verdict;
+        var summary = result.summaryLines.join("\n");
+        var html = "";
+        html += '<div class="rush-result is-' + escapeHtml(result.verdict) + '">';
+        html += '<div class="rush-verdict-badge">' + escapeHtml(verdictLabel) + "</div>";
+        html += "<h4>" + escapeHtml(STRINGS.resultHeading) + "</h4>";
+        html += "<p>" + escapeHtml(result.message) + "</p>";
+        html += '<p class="rush-earliest"><strong>' + escapeHtml(STRINGS.earliest) + ":</strong> " +
+            escapeHtml(bd.formatDate(result.earliestDate)) + "</p>";
+        if (rules.maxRushPerDay) {
+            html += '<p class="muted">' + escapeHtml(STRINGS.capacityNote(rules.maxRushPerDay)) + "</p>";
+        }
+        html += '<pre class="rush-summary">' + escapeHtml(summary) + "</pre>";
+        html += '<div class="rush-actions">' +
+            '<button type="button" class="coverage-button" id="rush-restart">' + escapeHtml(STRINGS.startOver) + "</button>" +
+            '<button type="button" class="coverage-button rush-primary" id="rush-copy">' + escapeHtml(STRINGS.copy) + "</button>" +
+            "</div>";
+        html += "</div>";
+        root.innerHTML = html;
+
+        var restart = root.querySelector("#rush-restart");
+        if (restart) restart.addEventListener("click", function () {
+            state.index = 0;
+            state.answers = {};
+            state.result = null;
+            render();
+        });
+        var copy = root.querySelector("#rush-copy");
+        if (copy) copy.addEventListener("click", function () { copyText(summary, copy); });
+    }
+
+    // ---- events ------------------------------------------------------------
+    function wireStep(step) {
+        var chips = root.querySelectorAll(".rush-choice");
+        Array.prototype.forEach.call(chips, function (chip) {
+            chip.addEventListener("click", function () {
+                state.answers[step.id] = chip.getAttribute("data-value");
+                render(); // re-render so the .active highlight updates
+            });
+        });
+        var field = root.querySelector("#rush-field");
+        if (field) {
+            field.addEventListener("input", function () { state.answers[step.id] = field.value; });
+        }
+        var back = root.querySelector("#rush-back");
+        if (back) back.addEventListener("click", goBack);
+        var next = root.querySelector("#rush-next");
+        if (next) next.addEventListener("click", goNext);
+    }
+
+    function showError(msg) {
+        var el = root.querySelector("#rush-error");
+        if (el) el.textContent = msg || "";
+    }
+
+    function goBack() {
+        if (state.index > 0) {
+            state.index--;
+            state.result = null;
+            render();
+        }
+    }
+
+    function goNext() {
+        var step = currentStep();
+        var err = stepError(step);
+        if (err) { showError(err); return; }
+        if (state.index === state.steps.length - 1) {
+            compute();
+        } else {
+            state.index++;
+        }
+        render();
+    }
+
+    function compute() {
+        state.result = rules.decide(state.answers, {
+            now: new Date(),
+            bd: bd,
+            holidays: rules.holidays
+        });
+    }
+
+    // ---- clipboard ---------------------------------------------------------
+    function copyText(text, btn) {
+        function done() {
+            var old = btn.textContent;
+            btn.textContent = STRINGS.copied;
+            setTimeout(function () { btn.textContent = old; }, 1500);
+        }
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done, function () { fallbackCopy(text); done(); });
+        } else {
+            fallbackCopy(text);
+            done();
+        }
+    }
+
+    function fallbackCopy(text) {
+        var ta = document.createElement("textarea");
+        ta.value = text;
+        ta.style.position = "fixed";
+        ta.style.opacity = "0";
+        document.body.appendChild(ta);
+        ta.select();
+        try { document.execCommand("copy"); } catch (e) { /* ignore */ }
+        document.body.removeChild(ta);
+    }
+
+    render();
+});

--- a/RushRequestsDev/businessDays.js
+++ b/RushRequestsDev/businessDays.js
@@ -1,0 +1,127 @@
+/*
+ * businessDays.js — pure business-day date math (no DOM, no dependencies).
+ *
+ * Attaches a single namespace, window.businessDays, mirroring the data-module
+ * pattern used by fingerSizes.js / contacts.js in DesignBuddyDesktop. Every
+ * function is pure so this file can be dropped into DesignBuddyDesktop verbatim
+ * (or inlined at module scope next to calcEternityStoneCount) when the
+ * questionnaire is migrated into a tab.
+ *
+ * Holidays are passed in as an array of "YYYY-MM-DD" strings; this file never
+ * imports the rules config, so the owner maintains holidays in rushRules.js.
+ */
+window.businessDays = (function () {
+    // Strip the time component -> local midnight. Avoids DST / time-of-day drift.
+    function startOfDay(date) {
+        var d = new Date(date);
+        return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+    }
+
+    // Stable "YYYY-MM-DD" key in LOCAL time (used for holiday lookups + <input min>).
+    function ymd(date) {
+        var d = startOfDay(date);
+        var m = String(d.getMonth() + 1).padStart(2, "0");
+        var day = String(d.getDate()).padStart(2, "0");
+        return d.getFullYear() + "-" + m + "-" + day;
+    }
+
+    function addCalendarDays(date, n) {
+        var d = startOfDay(date);
+        d.setDate(d.getDate() + n);
+        return d;
+    }
+
+    function isWeekend(date) {
+        var day = startOfDay(date).getDay(); // 0 = Sunday ... 6 = Saturday
+        return day === 0 || day === 6;
+    }
+
+    function isHoliday(date, holidays) {
+        if (!holidays || !holidays.length) return false;
+        return holidays.indexOf(ymd(date)) !== -1;
+    }
+
+    function isBusinessDay(date, holidays) {
+        return !isWeekend(date) && !isHoliday(date, holidays);
+    }
+
+    // First business day on OR after `date`.
+    function nextBusinessDayOnOrAfter(date, holidays) {
+        var d = startOfDay(date);
+        var guard = 0;
+        while (!isBusinessDay(d, holidays)) {
+            d = addCalendarDays(d, 1);
+            if (++guard > 3650) break; // safety valve
+        }
+        return d;
+    }
+
+    // First business day STRICTLY after `date`.
+    function nextBusinessDay(date, holidays) {
+        return nextBusinessDayOnOrAfter(addCalendarDays(date, 1), holidays);
+    }
+
+    // Advance `n` business days from `startDate`.
+    //   n = 0  -> the soonest business day on/after startDate.
+    //   n >= 1 -> that many business days beyond that soonest day.
+    function addBusinessDays(startDate, n, holidays) {
+        var d = nextBusinessDayOnOrAfter(startDate, holidays);
+        var remaining = Math.max(0, Math.floor(n || 0));
+        var guard = 0;
+        while (remaining > 0) {
+            d = addCalendarDays(d, 1);
+            if (isBusinessDay(d, holidays)) remaining--;
+            if (++guard > 3650) break; // safety valve
+        }
+        return d;
+    }
+
+    // Count of business days in the interval (a, b] — excludes a, includes b.
+    // Returns 0 when b is on or before a.
+    function businessDaysBetween(a, b, holidays) {
+        var start = startOfDay(a);
+        var end = startOfDay(b);
+        if (end <= start) return 0;
+        var count = 0;
+        var d = addCalendarDays(start, 1);
+        var guard = 0;
+        while (d <= end) {
+            if (isBusinessDay(d, holidays)) count++;
+            d = addCalendarDays(d, 1);
+            if (++guard > 3650) break; // safety valve
+        }
+        return count;
+    }
+
+    // Parse a "YYYY-MM-DD" string (from <input type="date">) as LOCAL midnight,
+    // NOT UTC, to avoid an off-by-one day across timezones.
+    function parseInputDate(value) {
+        if (!value) return null;
+        var parts = String(value).split("-").map(Number);
+        if (parts.length !== 3 || parts.some(isNaN)) return null;
+        return new Date(parts[0], parts[1] - 1, parts[2]);
+    }
+
+    function formatDate(date, locale) {
+        return startOfDay(date).toLocaleDateString(locale || "en-CA", {
+            weekday: "short",
+            year: "numeric",
+            month: "short",
+            day: "numeric"
+        });
+    }
+
+    return {
+        startOfDay: startOfDay,
+        ymd: ymd,
+        isWeekend: isWeekend,
+        isHoliday: isHoliday,
+        isBusinessDay: isBusinessDay,
+        nextBusinessDay: nextBusinessDay,
+        nextBusinessDayOnOrAfter: nextBusinessDayOnOrAfter,
+        addBusinessDays: addBusinessDays,
+        businessDaysBetween: businessDaysBetween,
+        parseInputDate: parseInputDate,
+        formatDate: formatDate
+    };
+})();

--- a/RushRequestsDev/index.html
+++ b/RushRequestsDev/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="." />
+    <link rel="icon" type="image/svg+xml" href="../assets/svg/logo.svg" />
+    <title>Rush Requests (Dev)</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="header">
+      <h2>Rush Requests</h2>
+      <a class="back" onclick="history.back()">Back</a>
+    </div>
+
+    <main>
+      <p class="calculator-description">
+        Answer a few quick questions to get an instant rush decision and the
+        earliest achievable date &mdash; no email approval needed.
+      </p>
+      <div id="rush-app" class="rush-app"></div>
+      <noscript>This questionnaire requires JavaScript to be enabled.</noscript>
+    </main>
+
+    <!-- Load order matters: date utility, then rules, then the controller. -->
+    <script src="businessDays.js"></script>
+    <script src="rushRules.js"></script>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/RushRequestsDev/rushRules.js
+++ b/RushRequestsDev/rushRules.js
@@ -1,0 +1,145 @@
+/*
+ * ============================================================================
+ *  RUSH REQUEST BUSINESS RULES  —  *** EDIT ME ***
+ * ============================================================================
+ *  This is the ONLY file you need to touch to change how Rush Requests behave.
+ *  Every value below is a PLACEHOLDER guess — replace them with the real
+ *  CrownRing policy (holidays, cutoff, lead times, approval thresholds).
+ *
+ *  Loads as a plain <script> and attaches window.rushRules, exactly like
+ *  fingerSizes.js / contacts.js in DesignBuddyDesktop.
+ *  Requires window.businessDays (businessDays.js must load BEFORE this file).
+ * ============================================================================
+ */
+window.rushRules = {
+
+    // ---- 1. Calendar / capacity context ------------------------------------
+
+    // Company holidays (no production on these days). "YYYY-MM-DD".
+    // EDIT ME — use real CrownRing closure dates, and keep them current yearly.
+    holidays: [
+        "2026-01-01", // New Year's Day
+        "2026-07-01", // Canada Day
+        "2026-09-07", // Labour Day
+        "2026-12-25", // Christmas Day
+        "2026-12-26"  // Boxing Day
+    ],
+
+    // Daily order cutoff (local time, 24h "HH:MM"). A request submitted AFTER
+    // this time is treated as if it arrived the next business day. EDIT ME.
+    dailyCutoff: "12:00",
+
+    // Informational ceiling: how many rushes we think can be absorbed per day.
+    // NOTE: the dev build has no backend, so this is NOT enforced yet (there is
+    // no shared counter) — it is shown to the agent as guidance only. EDIT ME.
+    maxRushPerDay: 5,
+
+    // ---- 2. Per-work-type lead times (in BUSINESS days) --------------------
+    // key -> {
+    //   label                 : shown in the questionnaire,
+    //   leadTimeDays          : normal business-day lead time,
+    //   rushable              : false => ALWAYS escalate (cannot be auto-approved),
+    //   autoApproveWithinDays : auto-APPROVE only if the requested date leaves AT
+    //                           LEAST this many business days of buffer beyond the
+    //                           earliest achievable date; otherwise ESCALATE.
+    //                           Set to 0 to approve as soon as it is achievable.
+    // }
+    // EDIT ME — these numbers are placeholders.
+    workTypes: {
+        newCad:         { label: "New CAD design",              leadTimeDays: 5,  rushable: true,  autoApproveWithinDays: 2 },
+        cadRevision:    { label: "CAD revision",                leadTimeDays: 2,  rushable: true,  autoApproveWithinDays: 0 },
+        casting:        { label: "Casting",                     leadTimeDays: 7,  rushable: true,  autoApproveWithinDays: 3 },
+        stoneSetting:   { label: "Stone setting",               leadTimeDays: 4,  rushable: true,  autoApproveWithinDays: 1 },
+        finishing:      { label: "Polishing / finishing",       leadTimeDays: 2,  rushable: true,  autoApproveWithinDays: 0 },
+        fullProduction: { label: "Full production (all steps)", leadTimeDays: 15, rushable: false, autoApproveWithinDays: 0 }
+    },
+
+    // ---- 3. Questionnaire definition (drives the wizard UI) ----------------
+    // The wizard renders these steps in array order. EDIT ME freely.
+    //   type: "text" | "single" | "date" | "number" | "info"
+    //   id  : the key the answer is stored under
+    //   optionsFrom: "workTypes" auto-builds the choices from workTypes above
+    questions: [
+        { id: "agentName",     type: "text",   label: "Your name",                     required: true,  placeholder: "e.g. Alex" },
+        { id: "orderRef",      type: "text",   label: "Order / job number",            required: true,  placeholder: "e.g. CR-12345" },
+        { id: "workType",      type: "single", label: "What work is being requested?", required: true,  optionsFrom: "workTypes" },
+        { id: "requestedDate", type: "date",   label: "Requested delivery date",       required: true },
+        { id: "notes",         type: "text",   label: "Anything else we should know?", required: false, placeholder: "Optional" }
+    ],
+
+    // ---- 4. Decision function: answers -> verdict --------------------------
+    // ctx = { now: Date, bd: window.businessDays, holidays: [...] }
+    // returns { earliestDate, verdict, message, summaryLines }
+    //   verdict is one of: "approved" | "escalate" | "denied"
+    // EDIT ME — this single function is the whole policy.
+    decide: function (answers, ctx) {
+        var bd = ctx.bd;
+        var holidays = this.holidays;
+        var wt = this.workTypes[answers.workType];
+
+        // 1) Clock start = today, bumped to the next business day if we're past
+        //    the daily cutoff (or today isn't a business day).
+        var start = bd.startOfDay(ctx.now);
+        var cutoff = String(this.dailyCutoff || "23:59").split(":").map(Number);
+        var pastCutoff =
+            ctx.now.getHours() > cutoff[0] ||
+            (ctx.now.getHours() === cutoff[0] && ctx.now.getMinutes() >= (cutoff[1] || 0));
+        if (pastCutoff || !bd.isBusinessDay(start, holidays)) {
+            start = bd.nextBusinessDay(start, holidays);
+        }
+
+        // 2) Earliest achievable date = start + lead time (in business days).
+        var leadTime = wt ? wt.leadTimeDays : 0;
+        var earliestDate = bd.addBusinessDays(start, leadTime, holidays);
+
+        // 3) Compare the requested date against the earliest achievable date.
+        var requested = bd.parseInputDate(answers.requestedDate);
+        var verdict, message;
+
+        if (!wt || !wt.rushable) {
+            verdict = "escalate";
+            message = (wt ? wt.label : "This work") +
+                " can't be auto-approved as a rush — escalating to a manager. Earliest realistic date: " +
+                bd.formatDate(earliestDate) + ".";
+        } else if (requested && requested < earliestDate) {
+            verdict = "escalate";
+            message = "Requested date " + bd.formatDate(requested) +
+                " is sooner than the earliest achievable date " + bd.formatDate(earliestDate) +
+                ". Escalating for manager review.";
+        } else {
+            // Business days of buffer between the earliest date and the requested date.
+            var runway = requested ? bd.businessDaysBetween(earliestDate, requested, holidays) : 0;
+            if (runway >= (wt.autoApproveWithinDays || 0)) {
+                verdict = "approved";
+                message = "Approved. We can deliver " + wt.label.toLowerCase() +
+                    " by " + bd.formatDate(requested || earliestDate) + ".";
+            } else {
+                verdict = "escalate";
+                message = "Tight timeline — only " + runway +
+                    " business day(s) of buffer past the earliest date. Escalating for confirmation. Earliest safe date: " +
+                    bd.formatDate(earliestDate) + ".";
+            }
+        }
+
+        return {
+            earliestDate: earliestDate,
+            verdict: verdict,
+            message: message,
+            summaryLines: buildSummary(answers, earliestDate, verdict, this)
+        };
+    }
+};
+
+// Builds the copy-to-clipboard summary lines. EDIT ME to change the format.
+function buildSummary(answers, earliestDate, verdict, rules) {
+    var wt = rules.workTypes[answers.workType];
+    return [
+        "RUSH REQUEST — " + verdict.toUpperCase(),
+        "Agent: " + (answers.agentName || "-"),
+        "Order: " + (answers.orderRef || "-"),
+        "Work: " + (wt ? wt.label : (answers.workType || "-")),
+        "Requested: " + (answers.requestedDate || "-"),
+        "Earliest achievable: " + window.businessDays.formatDate(earliestDate),
+        answers.notes ? "Notes: " + answers.notes : null
+    ].filter(Boolean);
+}

--- a/RushRequestsDev/style.css
+++ b/RushRequestsDev/style.css
@@ -1,0 +1,204 @@
+/*
+ * RushRequestsDev — standalone dev styling.
+ *
+ * Mirrors DesignBuddyDesktop/style.css so the questionnaire already looks like
+ * a DBD tab. The reused classes below are kept identical to DBD; the .rush-*
+ * classes at the bottom are the new ones that migrate into DBD style.css later.
+ * The .header / .back chrome is dev-only and is dropped on migration.
+ */
+
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+    background-color: #fff;
+    color: #000;
+}
+
+/* ---- dev-only chrome (dropped on migration) ---------------------------- */
+.header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid #000;
+}
+
+.header h2 {
+    margin: 0;
+    font-size: 1.25rem;
+}
+
+.header .back {
+    padding: 0.4rem 1rem;
+    background: #000;
+    color: #fff;
+    border: 1px solid #000;
+    border-radius: 5px;
+    text-decoration: none;
+    cursor: pointer;
+    font-size: 0.9rem;
+}
+
+.header .back:hover {
+    background: #333;
+}
+
+main {
+    padding: 1rem;
+}
+
+/* ---- reused DBD classes (keep in sync with DesignBuddyDesktop/style.css) - */
+label {
+    font-weight: bold;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+input, select {
+    padding: 0.5rem;
+    font-size: 1rem;
+    margin-bottom: 1rem;
+    border: 1px solid #000;
+    border-radius: 5px;
+}
+
+.calculator-description {
+    background: #f9f9f9;
+    border: 1px solid #000;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+}
+
+.coverage-button {
+    flex: 1;
+    padding: 0.5rem;
+    font-size: 1rem;
+    border: 1px solid #000;
+    border-radius: 5px;
+    background: #f5f5f5;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.coverage-button:hover,
+.coverage-button:focus {
+    background: #e0e0e0;
+    outline: none;
+}
+
+.coverage-button.active {
+    background: #000;
+    color: #fff;
+    border-color: #000;
+}
+
+.coverage-button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.muted {
+    color: #666;
+    font-size: 0.9rem;
+}
+
+/* ---- new .rush-* classes (migrate into DBD style.css) ------------------ */
+.rush-app {
+    max-width: 640px;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.rush-progress {
+    font-size: 0.9rem;
+    color: #555;
+    font-weight: bold;
+}
+
+.rush-step {
+    display: flex;
+    flex-direction: column;
+}
+
+.rush-step input[type="text"],
+.rush-step input[type="number"],
+.rush-step input[type="date"] {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.rush-choice-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.rush-error {
+    color: #b00020;
+    font-weight: bold;
+    min-height: 1.2rem;
+}
+
+.rush-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.rush-primary {
+    background: #000;
+    color: #fff;
+    border-color: #000;
+}
+
+.rush-primary:hover {
+    background: #333;
+}
+
+.rush-result {
+    border: 1px solid #000;
+    border-left-width: 6px;
+    border-radius: 8px;
+    padding: 1rem;
+    background: #f9f9f9;
+}
+
+.rush-result h4 {
+    margin: 0.5rem 0;
+}
+
+.rush-result.is-approved { border-left-color: #1a7f37; }
+.rush-result.is-escalate { border-left-color: #b58105; }
+.rush-result.is-denied   { border-left-color: #b00020; }
+
+.rush-verdict-badge {
+    display: inline-block;
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: #fff;
+    background: #555;
+}
+
+.rush-result.is-approved .rush-verdict-badge { background: #1a7f37; }
+.rush-result.is-escalate .rush-verdict-badge { background: #b58105; }
+.rush-result.is-denied   .rush-verdict-badge { background: #b00020; }
+
+.rush-earliest {
+    font-size: 1.05rem;
+}
+
+.rush-summary {
+    margin: 1rem 0 0 0;
+    padding: 1rem;
+    border: 1px solid #000;
+    border-radius: 5px;
+    background: #fff;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: ui-monospace, Menlo, Consolas, monospace;
+    font-size: 0.9rem;
+}


### PR DESCRIPTION
Interactive, client-side questionnaire that gives agents an instant rush
decision and the earliest achievable date instead of waiting for an email
approval. Built as a self-contained RushRequestsDev/ app (matching the repo's
folder-per-project convention) so it can be migrated into a DesignBuddyDesktop
tab later.

- businessDays.js: pure business-day date math (weekends + holidays), reusable
- rushRules.js: single editable file for all business rules (holidays, daily
  cutoff, per-work-type lead times, questionnaire definition, and the decision
  function) with clearly-marked placeholder values
- app.js: vanilla-JS render-from-state wizard controller, structured to lift
  into a setupRushRequests() tab hook
- index.html / style.css: standalone chrome reusing DesignBuddyDesktop styles

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AfrK4nFNaWCsAaMT7JNcSr